### PR TITLE
Fix issue with nonce not being incremental

### DIFF
--- a/cexio.js
+++ b/cexio.js
@@ -25,7 +25,6 @@ var CEXIO = function(pair, clientId, key, secret) {
   this.clientId = clientId;
   this.key = key;
   this.secret = secret;
-  this.nonce = new Date().getTime()
   self = this
   _.each(_.functions(self), function(f) {
     self[f] = _.bind(self[f], self);
@@ -99,7 +98,7 @@ CEXIO.prototype._post = function(action, pair, callback, args) {
   } else {
     path = '/api/' + action + '/'
   }
-  nonce = this.nonce++;
+  var nonce = new Date().getTime();
   args = _.extend({nonce: nonce, key: this.key}, args);
   args = _.compactObject(args);
   var message = nonce.toString() + this.clientId + this.key

--- a/cexio.js
+++ b/cexio.js
@@ -25,7 +25,7 @@ var CEXIO = function(pair, clientId, key, secret) {
   this.clientId = clientId;
   this.key = key;
   this.secret = secret;
-  self = this
+  var self = this;
   _.each(_.functions(self), function(f) {
     self[f] = _.bind(self[f], self);
   });
@@ -33,9 +33,9 @@ var CEXIO = function(pair, clientId, key, secret) {
 
 CEXIO.prototype._request = function(method, path, data, callback, args) {
   if (data) {
-    contentLength = data.length
+    contentLength = data.length;
   } else {
-    contentLength = 0
+    contentLength = 0;
   }
   var options = {
     host: 'cex.io',
@@ -44,7 +44,7 @@ CEXIO.prototype._request = function(method, path, data, callback, args) {
     headers: {
       'User-Agent': 'Mozilla/4.0 (Node.js CEXIO client)',
       'Content-Type': 'application/x-www-form-urlencoded',
-      'Content-Length': contentLength,
+      'Content-Length': contentLength
     }
   };
   var req = https.request(options, function(res) {
@@ -80,12 +80,12 @@ CEXIO.prototype._get = function(action, pair, callback, args) {
   var path;
   if (pair) {
     assets = getAssets(pair);
-    path = '/api/' + action + '/'+assets[0]+'/'+assets[1]
+    path = '/api/' + action + '/'+assets[0]+'/'+assets[1];
   } else {
-    path = '/api/' + action
+    path = '/api/' + action;
   }
   path += '/?' + querystring.stringify(args);
-  this._request('get', path, undefined, callback, args)
+  this._request('get', path, undefined, callback, args);
 }
 
 CEXIO.prototype._post = function(action, pair, callback, args) {
@@ -94,17 +94,17 @@ CEXIO.prototype._post = function(action, pair, callback, args) {
   var path;
   if (pair) {
     assets = getAssets(pair);
-    path = '/api/' + action + '/'+assets[0]+'/'+assets[1]+'/'
+    path = '/api/' + action + '/'+assets[0]+'/'+assets[1]+'/';
   } else {
-    path = '/api/' + action + '/'
+    path = '/api/' + action + '/';
   }
   var nonce = new Date().getTime();
   args = _.extend({nonce: nonce, key: this.key}, args);
   args = _.compactObject(args);
-  var message = nonce.toString() + this.clientId + this.key
+  var message = nonce.toString() + this.clientId + this.key;
   var hmac = crypto.createHmac("sha256", new Buffer(this.secret));
   hmac.update(message);
-  signature = hmac.digest("hex").toUpperCase()
+  signature = hmac.digest("hex").toUpperCase();
   args.signature = signature;
   var data = querystring.stringify(args);
   this._request('post', path, data, callback, args);


### PR DESCRIPTION
I was getting errors from the CEX.IO api where the nonce was lower than a previous nonce (causing all other requests to be ignored).

By always basing the nonce on the unix timestamp we're covering all bases.
